### PR TITLE
fix(modal): add animate-fade-in only when open

### DIFF
--- a/components/modal.tsx
+++ b/components/modal.tsx
@@ -13,7 +13,7 @@ export default function IframeModal({ src, isOpen, close }: Props) {
       isOpen && (
         <div
           className={
-            "fixed top-0 left-0 right-0 bottom-0 z-10 bg-black/90 flex animate-fade-in opacity-0" +
+            "fixed top-0 left-0 right-0 bottom-0 z-10 bg-black/90 flex opacity-0" +
             (isOpen ? " animate-fade-in" : "")
           }
           onClick={() => close()}


### PR DESCRIPTION
Hey! This PR removes the default `animate-fade-in` class for the modal and ensures it is only added when the modal is open